### PR TITLE
Change invalidCountMiddleware evaluation

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -59,7 +59,7 @@ function invalidCountMiddleware(request, response, next) {
   if (
     request.query &&
     request.query.count &&
-    request.query.count != undefined
+    request.query.count == undefined
   ) {
     response
       .status(400)


### PR DESCRIPTION

### Description of Changes for Review:

Unable to get more results with count - parameter.
Happens due to wrong evaluation of count parameter.

``` javascript
    request.query.count != undefined
``` 

Change evaluation to equals for the fix:

``` javascript
    request.query.count == undefined
``` 

closes #181 