### PR TITLE
ESP

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ Response
 }
 ```
 
+#### Supported Languages
+
+The supported languages are listed below, you can use any of the `lang Values` in the first column as a `lang` param. 
+
+"?lang=esp" and "?lang=esp-mx" will both return spanish for your response, and simply using the `ISO-639-1` code will default to esp-mx for simplicity. 
+
+| LANG Variable | [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) | Language Name | Localization (country) |
+| :---: | :---: | :---: | :---: |
+| `eng-us`  | `eng` | English | USA |
+| `ukr-ua`  | `ukr` | Ukrainian | UA |
+| `rus-ru`  | `rus` | Russian | RUS |
+| `esp-es`  | `esp` | Spanish | ES |
+| `esp-mx`  | `esp` | Spanish (default) | MX |
+
+
+<details>
+  <summary>Help us expand and improve Internationalization on this API  (Click to expand)</summary>
+  <h3>Help us expand and improve Internationalization on this API</h3>
+  
+  <p><b>Note:</b> We are trying to follow the browser's language tags, which are formally defined in <a href="https://datatracker.ietf.org/doc/html/rfc5646">RFC 5646</a>, which rely on the <a href="https://en.wikipedia.org/wiki/ISO_639">ISO 639</a> standard (quite often the <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">639-1 code list</a>) for <a href="https://en.wikipedia.org/wiki/Language_code">language codes</a> to be used.</p> 
+
+<p>We would love it if you helped this project by taking a look at our <a href="https://github.com/wh-iterabb-it/meowfacts/issues/175">Call for Contributors</a> to see if you can make a contribution that helps us be more inclusive and support more languages. </p>
+</details>
+
+
 ### Documentation
 
 <div align="center">

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,7 +1,9 @@
 const facts = require("./models/facts");
 const { convert } = require("sst");
 
-const VALID_LANGUAGES = ["eng", "ukr", "rus", "esp-mx", "esp-es"];
+const ISO_LANG = ["eng-us", "ukr-ua", "rus-ru", "esp-mx", "esp-es"];
+const SHORT_LANG = ["eng", "ukr", "rus", "esp"];
+const VALID_LANGUAGES = SHORT_LANG.concat(ISO_LANG);
 
 /**
  * Check if user entered valid count parameter

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,7 +1,7 @@
 const facts = require("./models/facts");
 const { convert } = require("sst");
 
-const VALID_LANGUAGES = ["eng", "ukr", "rus"];
+const VALID_LANGUAGES = ["eng", "ukr", "rus", "esp-mx", "esp-es"];
 
 /**
  * Check if user entered valid count parameter

--- a/src/models/facts.js
+++ b/src/models/facts.js
@@ -1,6 +1,8 @@
 const english = require("./localization/eng-US");
 const russian = require("./localization/rus-RU");
 const ukraine = require("./localization/ukr-UA");
+const spanishMexico = require("./localization/esp-MX");
+const spanishSpain = require("./localization/esp-ES");
 
 /**
  *
@@ -15,6 +17,10 @@ function getLanguageFacts(langName) {
       return russian.facts;
     case "ukr": // ukrainian
       return ukraine.facts;
+    case "esp-mx": // spanish Mexico
+      return spanishMexico.facts;
+    case "esp-es": // spanish Spain
+      return spanishSpain.facts;
     case undefined: // no language specified
     default:
       return english.facts;

--- a/src/models/facts.js
+++ b/src/models/facts.js
@@ -11,16 +11,20 @@ const spanishSpain = require("./localization/esp-ES");
  */
 function getLanguageFacts(langName) {
   switch (langName) {
-    case "eng": // english ... default us
+    case "eng-us": // english
+    case "eng": // default english
       return english.facts;
-    case "rus": // russian
+    case "rus-ru": // russian
+    case "rus": // default russian
       return russian.facts;
-    case "ukr": // ukrainian
+    case "ukr-ua": // ukrainian
+    case "ukr": // default ukrainian
       return ukraine.facts;
-    case "esp-mx": // spanish Mexico
-      return spanishMexico.facts;
     case "esp-es": // spanish Spain
       return spanishSpain.facts;
+    case "esp-mx": // spanish Mexico
+    case "esp": // default spanish
+      return spanishMexico.facts;
     case undefined: // no language specified
     default:
       return english.facts;

--- a/src/models/localization/esp-ES.js
+++ b/src/models/localization/esp-ES.js
@@ -1,0 +1,7 @@
+const facts = [
+  "En 1987, los gatos superaron a los perros como la mascota número uno en Estados Unidos.",
+];
+
+module.exports = {
+  facts: facts,
+};

--- a/src/models/localization/esp-MX.js
+++ b/src/models/localization/esp-MX.js
@@ -1,0 +1,7 @@
+const facts = [
+  "En 1987, los gatos superaron a los perros como la mascota número uno en Estados Unidos.",
+];
+
+module.exports = {
+  facts: facts,
+};


### PR DESCRIPTION
# Example of adding a new language PR 

I want to adhere to the Standards for [Content-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language) and [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) going forward. 

> **Note**: Language tags are formally defined in [RFC 5646](https://datatracker.ietf.org/doc/html/rfc5646), which rely on the [ISO 639](https://en.wikipedia.org/wiki/ISO_639) standard (quite often the [ISO 639-1 code list](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) for [language codes](https://en.wikipedia.org/wiki/Language_code) to be used.

This PR is made to demonstrate a start to https://github.com/wh-iterabb-it/meowfacts/issues/186 as it may be hard to make contributions before we supported 2 locals for the same language. 

